### PR TITLE
Add default values

### DIFF
--- a/src/Session/FlashGlobals.js
+++ b/src/Session/FlashGlobals.js
@@ -16,7 +16,7 @@ module.exports = function (View) {
     return _.get(this.resolve('flashMessages'), key, defaultValue)
   })
 
-  View.global('flashMessage', function (key, defaultValue = '') {
+  View.global('flashMessage', function (key, defaultValue) {
     return this.resolve('old')(key, defaultValue)
   })
 

--- a/src/Session/FlashGlobals.js
+++ b/src/Session/FlashGlobals.js
@@ -12,11 +12,11 @@
 const _ = require('lodash')
 
 module.exports = function (View) {
-  View.global('old', function (key, defaultValue) {
+  View.global('old', function (key, defaultValue = '') {
     return _.get(this.resolve('flashMessages'), key, defaultValue)
   })
 
-  View.global('flashMessage', function (key, defaultValue) {
+  View.global('flashMessage', function (key, defaultValue = '') {
     return this.resolve('old')(key, defaultValue)
   })
 

--- a/test/flash.spec.js
+++ b/test/flash.spec.js
@@ -160,6 +160,14 @@ test.group('Flash View Globals', (group) => {
     View.setData('flashMessages', { username: 'virk' })
     assert.equal(View.resolve('old')('username'), 'virk')
   })
+  
+  test('return the default value in old method', (assert) => {
+    assert.equal(View.resolve('old')('not_defined' , 'not defined'), 'not defined')
+  })
+
+  test('return a blank string as the default value when no default value is set', (assert) => {
+    assert.equal(View.resolve('old')('not_defined'), '')
+  })
 
   test('return error messages from flash messages', (assert) => {
     View

--- a/test/flash.spec.js
+++ b/test/flash.spec.js
@@ -160,9 +160,9 @@ test.group('Flash View Globals', (group) => {
     View.setData('flashMessages', { username: 'virk' })
     assert.equal(View.resolve('old')('username'), 'virk')
   })
-  
+
   test('return the default value in old method', (assert) => {
-    assert.equal(View.resolve('old')('not_defined' , 'not defined'), 'not defined')
+    assert.equal(View.resolve('old')('not_defined', 'not defined'), 'not defined')
   })
 
   test('return a blank string as the default value when no default value is set', (assert) => {


### PR DESCRIPTION
We often use the old function without necessarily using the second parameter:

```blade
<input name="username" value="{{ old('username', '') }}" />
```

So I think it would be interesting to add an empty string as default.
So that we can do:
```blade
<input name="username" value="{{ old('username') }}" />
```

Just it.