### PR TITLE
fix: use same bson library as mongodb driver

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@adonisjs/generic-exceptions": "^2.0.1",
-    "bson": "^4.0.0-rc5",
+    "bson": "^1.1.0",
     "debug": "^4.1.0",
     "fs-extra": "^7.0.0",
     "lodash": "^4.17.11",

--- a/test/session.spec.js
+++ b/test/session.spec.js
@@ -258,7 +258,7 @@ test.group('Session Store', () => {
     const store = new Store()
     const id = '507f191e810c19729de860ea'
     const objId = new ObjectId(id)
-    assert.deepEqual(store._guardValue(objId), { d: id, t: 'ObjectId' })
+    assert.deepEqual(store._guardValue(objId), { d: id, t: 'ObjectID' })
   })
 
   test('unguard object', (assert) => {


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

There is an incompatibility between `bson` version 4.0.0 and the version used by the mongodb driver to serialize queries [(version ^1.0.4)](https://github.com/mongodb/node-mongodb-native/blob/c6f417e5fe54691783bccc466e7703a5d380739e/package.json#L25).

The serializer in `bson` 1.1.0 only checks for `_bsontype === 'ObjectID'`:
https://github.com/mongodb/js-bson/blob/v1.1.0/lib/bson/parser/serializer.js#L721-L723

In `bson` 4.0.0, the field was changed to `ObjectId` (notice the lowercase "d"):
https://github.com/mongodb/js-bson/blob/v4.0.1/lib/objectid.js#L50

This breaks `adonis-session` when used with `lucid-mongo` because the serialization ignores the `_id` as it doesn't have the expected `_bsontype`.

To fix this, we propose to stick with the `bson` version as used by the driver.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-session/blob/develop/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
